### PR TITLE
feat: LibraryApiClient 개발 및 테스트 작성

### DIFF
--- a/src/__tests__/fixtures/libraryFixtures.ts
+++ b/src/__tests__/fixtures/libraryFixtures.ts
@@ -1,0 +1,74 @@
+import { LibrarySearchResponse, Library } from '@/types';
+
+/**
+ * 테스트용 도서관 정보 생성 헬퍼
+ */
+export const createLibrary = (overrides: Partial<Library> = {}): Library => ({
+  libCode: 'LIB001',
+  libName: '테스트 도서관',
+  address: '서울특별시 강남구 테스트로 123',
+  tel: '02-1234-5678',
+  fax: '02-1234-5679',
+  latitude: '37.5665',
+  longitude: '126.9780',
+  homepage: 'https://testlibrary.kr',
+  closed: '매주 월요일',
+  operatingTime: '09:00~18:00',
+  ...overrides
+});
+
+/**
+ * 테스트용 도서관 검색 응답 생성 헬퍼
+ */
+export const createLibrarySearchResponse = (overrides: Partial<{
+  pageNo: number;
+  pageSize: number;
+  numFound: number;
+  resultNum: number;
+  libraryCount: number;
+  libraries: Library[];
+}> = {}): LibrarySearchResponse => {
+  const defaultLibraryCount = 2;
+  const defaults = {
+    pageNo: 1,
+    pageSize: 10,
+    numFound: 25,
+    resultNum: defaultLibraryCount,
+    libraryCount: defaultLibraryCount,
+    libraries: Array.from({ length: overrides.libraryCount || defaultLibraryCount }, (_, index) =>
+      createLibrary({ 
+        libCode: `LIB${String(index + 1).padStart(3, '0')}`, 
+        libName: `테스트 도서관 ${index + 1}`,
+        address: `서울특별시 강남구 테스트로 ${(index + 1) * 100}`
+      })
+    )
+  };
+
+  const merged = { ...defaults, ...overrides };
+  
+  // libraryCount가 변경되면 libraries도 다시 생성
+  if (overrides.libraryCount && !overrides.libraries) {
+    merged.libraries = Array.from({ length: merged.libraryCount }, (_, index) =>
+      createLibrary({ 
+        libCode: `LIB${String(index + 1).padStart(3, '0')}`, 
+        libName: `테스트 도서관 ${index + 1}`,
+        address: `서울특별시 강남구 테스트로 ${(index + 1) * 100}`
+      })
+    );
+  }
+
+  return {
+    pageNo: merged.pageNo,
+    pageSize: merged.pageSize,
+    numFound: merged.numFound,
+    resultNum: merged.resultNum,
+    libs: {
+      lib: merged.libraries
+    }
+  };
+};
+
+/**
+ * 기본 도서관 개수 상수
+ */
+export const DEFAULT_LIBRARY_COUNT = 2;

--- a/src/__tests__/services/LibraryApiClient.test.ts
+++ b/src/__tests__/services/LibraryApiClient.test.ts
@@ -1,0 +1,177 @@
+import { LibraryApiClient } from '@/services/libraryApiClient';
+import { ExternalApiService } from '@/services/externalApi';
+import { createLibrarySearchResponse, DEFAULT_LIBRARY_COUNT } from '@/__tests__/fixtures/libraryFixtures';
+
+jest.mock('@/services/externalApi');
+
+const MockedExternalApiService = ExternalApiService as jest.MockedClass<typeof ExternalApiService>;
+
+// 환경변수 모킹
+const originalEnv = process.env;
+
+beforeAll(() => {
+  process.env = {
+    ...originalEnv,
+    LIBRARY_API_KEY: 'test-api-key'
+  };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+describe('LibraryApiClient', () => {
+  let sut: LibraryApiClient;
+  let mockApiService: jest.Mocked<ExternalApiService>;
+
+  beforeEach(() => {
+    MockedExternalApiService.mockClear();
+    mockApiService = new MockedExternalApiService({} as any) as jest.Mocked<ExternalApiService>;
+    sut = new LibraryApiClient();
+    
+    // 목 서비스 주입
+    (sut as any).apiService = mockApiService;
+  });
+
+  describe('searchLibrariesByBook', () => {
+    it('ISBN으로 도서관 검색이 성공해야 함', async () => {
+      const mockResponse = createLibrarySearchResponse();
+      mockApiService.get.mockResolvedValue({
+        success: true,
+        data: mockResponse
+      });
+
+      const result = await sut.searchLibrariesByBook({
+        isbn: '9788936433529',
+        region: 11
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(result.data!.libs.lib).toHaveLength(DEFAULT_LIBRARY_COUNT);
+      expect(result.data!.numFound).toBe(25);
+
+      expect(mockApiService.get).toHaveBeenCalledWith(
+        expect.stringContaining('/libSrchByBook?')
+      );
+    });
+
+    it('커스텀 페이징으로 도서관 검색이 성공해야 함', async () => {
+      const mockResponse = createLibrarySearchResponse({
+        pageNo: 2,
+        pageSize: 5,
+        resultNum: 5
+      });
+      mockApiService.get.mockResolvedValue({
+        success: true,
+        data: mockResponse
+      });
+
+      const result = await sut.searchLibrariesByBook({
+        isbn: '9788936433529',
+        region: 11,
+        pageNo: 2,
+        pageSize: 5
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.pageNo).toBe(2);
+      expect(result.data!.pageSize).toBe(5);
+      expect(result.data!.resultNum).toBe(5);
+    });
+
+    it('세부지역과 함께 검색이 성공해야 함', async () => {
+      const mockResponse = createLibrarySearchResponse();
+      mockApiService.get.mockResolvedValue({
+        success: true,
+        data: mockResponse
+      });
+
+      const result = await sut.searchLibrariesByBook({
+        isbn: '9788936433529',
+        region: 11,
+        dtl_region: 11110
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockApiService.get).toHaveBeenCalledWith(
+        expect.stringContaining('dtl_region=11110')
+      );
+    });
+
+    it('다양한 개수의 도서관 검색 결과를 처리해야 함', async () => {
+      const libraryCount = 5;
+      const mockResponse = createLibrarySearchResponse({
+        libraryCount,
+        resultNum: libraryCount
+      });
+      mockApiService.get.mockResolvedValue({
+        success: true,
+        data: mockResponse
+      });
+
+      const result = await sut.searchLibrariesByBook({
+        isbn: '9788936433529',
+        region: 11
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data!.libs.lib).toHaveLength(libraryCount);
+      expect(result.data!.resultNum).toBe(libraryCount);
+    });
+
+    it('API 에러를 처리해야 함', async () => {
+      mockApiService.get.mockResolvedValue({
+        success: false,
+        error: 'API request failed'
+      });
+
+      const result = await sut.searchLibrariesByBook({
+        isbn: '9788936433529',
+        region: 11
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('API request failed');
+    });
+  });
+
+  describe('searchLibrariesByISBN', () => {
+    it('간편 ISBN 검색이 성공해야 함', async () => {
+      const mockResponse = createLibrarySearchResponse();
+      mockApiService.get.mockResolvedValue({
+        success: true,
+        data: mockResponse
+      });
+
+      const result = await sut.searchLibrariesByISBN('9788936433529');
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBeDefined();
+      expect(mockApiService.get).toHaveBeenCalledWith(
+        expect.stringContaining('isbn=9788936433529')
+      );
+    });
+
+    it('옵션과 함께 ISBN 검색이 성공해야 함', async () => {
+      const mockResponse = createLibrarySearchResponse();
+      mockApiService.get.mockResolvedValue({
+        success: true,
+        data: mockResponse
+      });
+
+      const result = await sut.searchLibrariesByISBN('9788936433529', {
+        dtl_region: 11110,
+        pageSize: 20
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockApiService.get).toHaveBeenCalledWith(
+        expect.stringContaining('dtl_region=11110')
+      );
+      expect(mockApiService.get).toHaveBeenCalledWith(
+        expect.stringContaining('pageSize=20')
+      );
+    });
+  });
+});

--- a/src/services/libraryApiClient.ts
+++ b/src/services/libraryApiClient.ts
@@ -1,0 +1,63 @@
+import dotenv from 'dotenv';
+import { ExternalApiService, ApiServiceConfig } from '@/services/externalApi';
+import { 
+  ServiceResult, 
+  LibrarySearchRequest,
+  LibrarySearchParams, 
+  LibrarySearchResponse 
+} from '@/types';
+
+dotenv.config();
+
+export class LibraryApiClient {
+  private readonly apiService: ExternalApiService;
+  private readonly authKey: string;
+  private readonly DEFAULT_REGION = 11; // 서울특별시
+
+  constructor() {
+    const config: ApiServiceConfig = {
+      baseURL: process.env.LIBRARY_API_BASE_URL || 'http://data4library.kr/api',
+      timeout: 15000,
+      retries: 3,
+    };
+
+    this.apiService = new ExternalApiService(config);
+
+    if (!process.env.LIBRARY_API_KEY) {
+      throw new Error('LIBRARY_API_KEY is required in environment variables');
+    }
+    this.authKey = process.env.LIBRARY_API_KEY;
+  }
+
+  async searchLibrariesByBook(params: LibrarySearchRequest): Promise<ServiceResult<LibrarySearchResponse>> {
+    const searchParams: LibrarySearchParams = {
+      authKey: this.authKey,
+      format: 'json',
+      pageNo: 1,
+      pageSize: 10,
+      region: this.DEFAULT_REGION,
+      ...params,
+    };
+
+    const queryString = this.buildQueryString(searchParams);
+    const endpoint = `/libSrchByBook?${queryString}`;
+
+    return this.apiService.get<LibrarySearchResponse>(endpoint);
+  }
+
+  async searchLibrariesByISBN(isbn: string, options?: Omit<LibrarySearchRequest, 'isbn'>): Promise<ServiceResult<LibrarySearchResponse>> {
+    return this.searchLibrariesByBook({ isbn, ...options });
+  }
+
+  private buildQueryString(params: LibrarySearchParams): string {
+    const searchParams = new URLSearchParams();
+    
+    Object.entries(params).forEach(([key, value]) => {
+      if (value !== undefined && value !== null) {
+        searchParams.append(key, value.toString());
+      }
+    });
+
+    return searchParams.toString();
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,49 @@ export interface PaginationMeta {
   totalPages: number;
 }
 
+// Library API Types
+export interface LibrarySearchRequest {
+  isbn: string;
+  region?: number;
+  dtl_region?: number;
+  pageNo?: number;
+  pageSize?: number;
+  format?: 'xml' | 'json';
+}
+
+export interface LibrarySearchParams {
+  authKey: string;
+  isbn: string;
+  region: number;
+  dtl_region?: number;
+  pageNo?: number;
+  pageSize?: number;
+  format?: 'xml' | 'json';
+}
+
+export interface Library {
+  libCode: string;
+  libName: string;
+  address: string;
+  tel: string;
+  fax: string;
+  latitude: string;
+  longitude: string;
+  homepage: string;
+  closed: string;
+  operatingTime: string;
+}
+
+export interface LibrarySearchResponse {
+  pageNo: number;
+  pageSize: number;
+  numFound: number;
+  resultNum: number;
+  libs: {
+    lib: Library[];
+  };
+}
+
 // Error Types
 export class AppError extends Error {
   public readonly statusCode: number;


### PR DESCRIPTION
도서관 정보나루 API 를 연결해 ISBN으로 소유 도서관 정보 조회. MVP 에선 서울 지역을 대상으로 진행

bss-13-add-library-api-client